### PR TITLE
Update WK_scattering_factors.py

### DIFF
--- a/py4DSTEM/process/diffraction/WK_scattering_factors.py
+++ b/py4DSTEM/process/diffraction/WK_scattering_factors.py
@@ -83,7 +83,7 @@ def compute_WK_factor(
     WK = np.zeros_like(S)
     for i in range(4):
         argu = B[i] * S**2
-        sub = argu < 1.0
+        sub = argu < 0.1
         WK[sub] += A[i] * B[i] * (1.0 - 0.5 * argu[sub])
         sub = np.logical_and(argu >= 1.0, argu <= 20.0)
         WK[sub] += A[i] * (1.0 - np.exp(-argu[sub])) / S[sub] ** 2


### PR DESCRIPTION
Typo changed the cut-off for WEKO argument from the correct value 0.1 to the incorrect value 1.0. This returns the value to 0.1 to match WK's F77 implementation ported to F90 by MDG:

https://github.com/EMsoft-org/EMsoftOO/blob/develop/Source/EMsoftOOLib/mod_others.f90#L191

"IF (ARGU .LT. .1) THEN"

When using 0.1:

![wk_scatter_with_0 1_no_artifacts](https://github.com/user-attachments/assets/20bbe887-f38c-4603-bbab-5b0ab06641e0)

When using 1.0:
![wk_scatter_with_1 0_artifacts](https://github.com/user-attachments/assets/0fd42ac9-c299-4a1c-9aee-034f9cab6c24)

(from my own PyTorch implementation).
